### PR TITLE
curl: add patch for curling directories

### DIFF
--- a/pkgs/tools/networking/curl/curl-accept-ranges-not-on-dirs.patch
+++ b/pkgs/tools/networking/curl/curl-accept-ranges-not-on-dirs.patch
@@ -1,0 +1,29 @@
+diff -r -u curl-7.76.0-pristine/lib/file.c curl-7.76.0/lib/file.c
+--- curl-7.76.0-pristine/lib/file.c	2021-02-22 11:47:54.000000000 +0000
++++ curl-7.76.0/lib/file.c	2021-04-03 17:23:47.677582417 +0000
+@@ -419,10 +419,12 @@
+         return result;
+     }
+ 
+-    result = Curl_client_write(data, CLIENTWRITE_HEADER,
+-                               (char *)"Accept-ranges: bytes\r\n", 0);
+-    if(result)
+-      return result;
++    if(!S_ISDIR(statbuf.st_mode)) {
++      result = Curl_client_write(data, CLIENTWRITE_HEADER,
++                                 (char *)"Accept-ranges: bytes\r\n", 0);
++      if(result)
++        return result;
++    }
+ 
+     filetime = (time_t)statbuf.st_mtime;
+     result = Curl_gmtime(filetime, &buffer);
+@@ -464,7 +466,7 @@
+     data->state.resume_from += (curl_off_t)statbuf.st_size;
+   }
+ 
+-  if(data->state.resume_from <= expected_size)
++  if(data->state.resume_from <= expected_size || data->state.resume_from == 0)
+     expected_size -= data->state.resume_from;
+   else {
+     failf(data, "failed to resume file:// transfer");

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -45,6 +45,10 @@ stdenv.mkDerivation rec {
     sha256 = "16n466an72fkick4j1phfg5a8p7f96vbnw80bgbr05bh6cvgx6z2";
   };
 
+  patches = [
+    ./curl-accept-ranges-not-on-dirs.patch
+  ];
+
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
   separateDebugInfo = stdenv.isLinux;
 


### PR DESCRIPTION
nix relies on using curl to fetch directories using the file scheme,
which got broken by the most recent curl update in
https://github.com/curl/curl/commit/1e5cec3297b143c1884fc0069afe247091122c2e
which no longer provides a content-length for directories, but in so
doing causes *any* fetch of a directory to return "Couldn't resume
download (36)" (which is easily testable using the CLI)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
