### PR TITLE
matrix-recorder: fix in the context of newer node2nix

### DIFF
--- a/pkgs/applications/networking/instant-messengers/matrix-recorder/composition.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-recorder/composition.nix
@@ -6,7 +6,7 @@
 
 let
   nodeEnv = import ./node-env.nix {
-    inherit (pkgs) lib stdenv python2 util-linux runCommand writeTextFile;
+    inherit (pkgs) lib stdenv python2 util-linux runCommand writeTextFile writeShellScript;
     inherit nodejs;
     libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
   };


### PR DESCRIPTION
###### Motivation for this change

A non-auto-updatable package was incompatible with fresh improvements

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Same output path as before
