### PR TITLE
discourse: 3.1.0 -> 3.2.1

### DIFF
--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -65,6 +65,7 @@ let
     gnutar
     git
     brotli
+    nodejs_18
 
     # Misc required system utils
     which
@@ -200,9 +201,14 @@ let
     pname = "discourse-assets";
     inherit version src;
 
+    yarnDevOfflineCache = fetchYarnDeps {
+      yarnLock = src + "/yarn.lock";
+      sha256 = "sha256-0s8c2V8Wl3f5kL1OIn2ps6hL7CUQD5+LJm+9LYHc+W0=";
+    };
+
     yarnOfflineCache = fetchYarnDeps {
-      yarnLock = src + "/app/assets/javascripts/yarn.lock";
-      sha256 = "sha256-ZBXvNdHHV92kSAswe6KA+OqaY5smf7ZKTTOiY8g78D0=";
+      yarnLock = src + "/app/assets/javascripts/yarn-ember5.lock";
+      sha256 = "0ggh7g4678ik9m5bczr6kdirmspqh2i7nc0b92jdsmy7s4syy5b4";
     };
 
     nativeBuildInputs = runtimeDeps ++ [
@@ -210,9 +216,7 @@ let
       redis
       nodePackages.uglify-js
       terser
-      nodePackages.patch-package
       yarn
-      nodejs_18
       jq
       moreutils
       prefetch-yarn-deps
@@ -234,16 +238,13 @@ let
       # assets precompilation task.
       ./assets_rake_command.patch
 
-      # `app/assets/javascripts/discourse/package.json`'s postinstall
-      # hook tries to call `../node_modules/.bin/patch-package`, which
-      # hasn't been `patchShebangs`-ed yet. So instead we just use
-      # `patch-package` from `nativeBuildInputs`.
-      ./assets_patch-package_from_path.patch
+      # Little does he know, so he decided there is no need to generate the
+      # theme-transpiler over and over again. Which at the same time allows the removal
+      # of javascript devDependencies from the runtime environment.
+      ./prebuild-theme-transpiler.patch
     ];
 
-    postPatch = ''
-      cp ${./yarn.lock} yarn.lock
-    '';
+    RAILS_ENV = "production";
 
     # We have to set up an environment that is close enough to
     # production ready or the assets:precompile task refuses to
@@ -253,26 +254,31 @@ let
       # Yarn wants a real home directory to write cache, config, etc to
       export HOME=$NIX_BUILD_TOP/fake_home
 
-      # Make yarn install packages from our offline cache, not the registry
-      yarn config --offline set yarn-offline-mirror $yarnOfflineCache
+      yarn_install() {
+        local offlineCache=$1 yarnLock=$2
 
-      # Fixup "resolved"-entries in yarn.lock to match our offline cache
-      fixup-yarn-lock yarn.lock
+        # Make yarn install packages from our offline cache, not the registry
+        yarn config --offline set yarn-offline-mirror $offlineCache
+
+        # Fixup "resolved"-entries in yarn.lock to match our offline cache
+        fixup-yarn-lock $yarnLock
+
+        # Install while ignoring hook scripts
+        yarn --offline --ignore-scripts --cwd $(dirname $yarnLock) install
+      }
+
+      # Install devDependencies for generating the theme-transpiler executed as
+      # dependent task assets:precompile:theme_transpiler before db:migrate
+      yarn_install $yarnDevOfflineCache yarn.lock
+
+      # Install the runtime dependencies
+      yarn_install $yarnOfflineCache app/assets/javascripts/yarn-ember5.lock
+
+      # Patch before running postinstall hook script
+      patchShebangs --build app/assets/javascripts
+      yarn --offline --cwd app/assets/javascripts run postinstall
 
       export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
-
-      find app/assets/javascripts -name package.json -print0 \
-        | xargs -0 -I {} bash -c "jq 'del(.scripts.postinstall)' -r <{} | sponge {}"
-      yarn install --offline --cwd app/assets/javascripts/discourse
-
-      patchShebangs app/assets/javascripts/node_modules/
-
-      # Run `patch-package` AFTER the corresponding shebang inside `.bin/patch-package`
-      # got patched. Otherwise this will fail with
-      #     /bin/sh: line 1: /build/source/app/assets/javascripts/node_modules/.bin/patch-package: cannot execute: required file not found
-      pushd app/assets/javascripts &>/dev/null
-        yarn run patch-package
-      popd &>/dev/null
 
       redis-server >/dev/null &
 
@@ -290,13 +296,7 @@ let
       psql 'discourse' -tAc "CREATE EXTENSION IF NOT EXISTS pg_trgm"
       psql 'discourse' -tAc "CREATE EXTENSION IF NOT EXISTS hstore"
 
-      # Create a temporary home dir to stop bundler from complaining
-      mkdir $NIX_BUILD_TOP/tmp_home
-      export HOME=$NIX_BUILD_TOP/tmp_home
-
       ${lib.concatMapStringsSep "\n" (p: "ln -sf ${p} plugins/${p.pluginName or ""}") plugins}
-
-      export RAILS_ENV=production
 
       bundle exec rake db:migrate >/dev/null
       chmod -R +w tmp
@@ -356,6 +356,11 @@ let
 
       # Make sure the notification email setting applies
       ./notification_email.patch
+
+      # Little does he know, so he decided there is no need to generate the
+      # theme-transpiler over and over again. Which at the same time allows the removal
+      # of javascript devDependencies from the runtime environment.
+      ./prebuild-theme-transpiler.patch
     ];
 
     postPatch = ''

--- a/pkgs/servers/web-apps/discourse/prebuild-theme-transpiler.patch
+++ b/pkgs/servers/web-apps/discourse/prebuild-theme-transpiler.patch
@@ -1,0 +1,21 @@
+diff --git a/lib/discourse_js_processor.rb b/lib/discourse_js_processor.rb
+index 26d142fa4d..6040aba6f4 100644
+--- a/lib/discourse_js_processor.rb
++++ b/lib/discourse_js_processor.rb
+@@ -68,7 +68,7 @@ class DiscourseJsProcessor
+     TRANSPILER_PATH =
+       (
+         if Rails.env.production?
+-          "tmp/theme-transpiler.js"
++          "app/assets/javascripts/theme-transpiler.js"
+         else
+           "tmp/theme-transpiler/#{Process.pid}.js"
+         end
+@@ -87,6 +87,6 @@ class DiscourseJsProcessor
+         "node",
+         "app/assets/javascripts/theme-transpiler/build.js",
+         TRANSPILER_PATH,
+-      )
++      ) if !Rails.env.production? or !File.file?(TRANSPILER_PATH)
+       TRANSPILER_PATH
+     end

--- a/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
       rack (>= 1.1.3)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.6)
     mini_racer (0.8.0)
       libv8-node (~> 18.16.0.0)
     mini_scheduler (0.16.0)

--- a/pkgs/servers/web-apps/discourse/rubyEnv/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/gemset.nix
@@ -1141,10 +1141,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1kl9c3kdchjabrihdqfmcplk3lq4cw1rr9f378y6q22qwy5dndvs";
+      sha256 = "149r94xi6b3jbp6bv72f8383b95ndn0p5sxnq11gs1j9jadv0ajf";
       type = "gem";
     };
-    version = "2.8.5";
+    version = "2.8.6";
   };
   mini_racer = {
     dependencies = ["libv8-node"];

--- a/pkgs/servers/web-apps/discourse/unicorn_logging_and_timeout.patch
+++ b/pkgs/servers/web-apps/discourse/unicorn_logging_and_timeout.patch
@@ -1,13 +1,13 @@
 diff --git a/config/unicorn.conf.rb b/config/unicorn.conf.rb
-index e69979adfe..68cb04a036 100644
+index 9fd348b074..40eb73b96e 100644
 --- a/config/unicorn.conf.rb
 +++ b/config/unicorn.conf.rb
-@@ -27,18 +27,10 @@ pid (ENV["UNICORN_PID_PATH"] || "#{discourse_path}/tmp/pids/unicorn.pid")
- 
+@@ -27,17 +27,9 @@ pid(ENV["UNICORN_PID_PATH"] || "#{discourse_path}/tmp/pids/unicorn.pid")
+
  if ENV["RAILS_ENV"] != "production"
    logger Logger.new(STDOUT)
 -  # we want a longer timeout in dev cause first request can be really slow
--  timeout (ENV["UNICORN_TIMEOUT"] && ENV["UNICORN_TIMEOUT"].to_i || 60)
+-  timeout(ENV["UNICORN_TIMEOUT"] && ENV["UNICORN_TIMEOUT"].to_i || 60)
 -else
 -  # By default, the Unicorn logger will write to stderr.
 -  # Additionally, some applications/frameworks log to stderr or stdout,
@@ -17,9 +17,8 @@ index e69979adfe..68cb04a036 100644
 -  # nuke workers after 30 seconds instead of 60 seconds (the default)
 -  timeout 30
  end
- 
-+timeout (ENV["UNICORN_TIMEOUT"] && ENV["UNICORN_TIMEOUT"].to_i || 60)
+
++timeout(ENV["UNICORN_TIMEOUT"] && ENV["UNICORN_TIMEOUT"].to_i || 60)
 +
  # important for Ruby 2.0
  preload_app true
- 

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -87,7 +87,7 @@ class DiscourseRepo:
         return self._latest_commit_sha
 
     def get_yarn_lock_hash(self, rev: str):
-        yarnLockText = self.get_file('yarn.lock', rev)
+        yarnLockText = self.get_file('app/assets/javascripts/yarn-ember5.lock', rev)
         with tempfile.NamedTemporaryFile(mode='w') as lockFile:
             lockFile.write(yarnLockText)
             return subprocess.check_output(['prefetch-yarn-deps', lockFile.name]).decode('utf-8').strip()


### PR DESCRIPTION
Fix installation of yarn dependencies. Discourse is moving the dependencies towards the root yarn.lock.
Currently in version 3.2.x the root yarn.lock does not replace app/assets/javascripts/yarn.lock but only holds the required devDependencies for building theme-transpiler.js which will be run as a dependent task of db:migrate when starting the service. 
In the next minor version 3.3.x the workspace list will move into the root yarn.lock (meaning dependencies will be installed in the root node_modules) and the app/assets/javascripts/yarn.lock will be removed, therefore the $yarnDevOfflineCache was not added to update.py.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
